### PR TITLE
Hardcode user/group ARGS

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,14 +12,14 @@ ARG group_name=ubuntu
 ARG group_id=1000
 
 # create user
-RUN groupadd -g ${group_id} ${group_name}
-RUN useradd -u ${user_id} -g ${group_id} -d /home/${user_name} \
-    --create-home --shell /bin/bash ${user_name}
-RUN echo "${user_name} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
-RUN chown -R ${user_name}:${group_name} /home/${user_name}
+RUN groupadd -g 1000 ubuntu
+RUN useradd -u 1000 -g 1000 -d /home/ubuntu \
+    --create-home --shell /bin/bash ubuntu
+RUN echo "ubuntu ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+RUN chown -R ubuntu:ubuntu /home/ubuntu
 
 # user settings
-ENV HOME /home/${user_name}
+ENV HOME /home/ubuntu
 ENV LANG en_US.UTF-8
 
 # Intall Anaconda
@@ -31,11 +31,11 @@ RUN echo 'export PATH=$HOME/anaconda3/bin:$PATH' > /etc/profile.d/anaconda.sh &&
 ENV PATH $HOME/anaconda3/bin:$PATH
 ENV LD_LIBRARY_PATH /usr/local/cuda-9.0/lib64:/usr/local/cuda-9.0/extras/CUPTI/lib64:$LD_LIBRARY_PATH
 
-RUN chown -R ${user_name}:${group_name} $HOME/anaconda3
+RUN chown -R ubuntu:ubuntu $HOME/anaconda3
 
 ##### Install Deeplabcut and its dependencies #####
 
-USER ${user_name}
+USER ubuntu
 WORKDIR /work
 
 # Install DeepLabCut


### PR DESCRIPTION
Hardcoding user and group ARGS into the shell commands fixed an issue I was having:

When passing ${user_name}:${group_name}, etc etc, the shell was reading all the args as "0" instead of 1000 etc. This caused the make to fail.

Step 8/27 : ARG group_id=1000
 ---> Using cache
 ---> 4e5b9a63b30e
Step 9/27 : RUN groupadd -g ${group_id} ${group_name}
 ---> Running in 30201b6ab1bb
groupadd: GID '0' already exists
The command '/bin/sh -c groupadd -g ${group_id} ${group_name}' returned a non-zero code: 4
Makefile:11: recipe for target 'docker-build' failed
make: *** [docker-build] Error 4

Step 8/27 : ARG group_id=1000
 ---> Using cache
 ---> 4e5b9a63b30e
Step 9/27 : RUN groupadd -g 1000 ubuntu
 ---> Running in 35d12c8401c4
Removing intermediate container 35d12c8401c4
 ---> 57185d9d33e8
Step 10/27 : RUN useradd -u ${user_id} -g ${group_id} -d /home/${user_name}     --create-home --shell /bin/bash ${user_name}
 ---> Running in 7d09306b8138
useradd: UID 0 is not unique
The command '/bin/sh -c useradd -u ${user_id} -g ${group_id} -d /home/${user_name}     --create-home --shell /bin/bash ${user_name}' returned a non-zero code: 4
Makefile:11: recipe for target 'docker-build' failed
make: *** [docker-build] Error 4